### PR TITLE
Fix Alt-d & F6 key to select urlbar

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -13,6 +13,8 @@ var settingsNames = ["personalOverNav","compressBookmarksToolbarItems","autoHide
 
 const { showLocationbar, selectSearchBox } = require("utils");
 const { Hotkey } = require("sdk/hotkeys");
+var system = require("sdk/system");
+const IS_MAC = system.platform === "darwin";
 var boundHotKeys = [];
 
 function onPrefChange(prefName){
@@ -57,12 +59,21 @@ function loadHotKeys(){
 	unloadHotKeys();
 	
 	if(simplePerfs.prefs["_selectLocationBarShortcut"]){
+    	boundHotKeys.push(Hotkey({
+    		combo: "f6",
+    		onPress: showLocationbar
+    	}));
 		boundHotKeys.push(Hotkey({
 		  combo: "accel-l",
 		  onPress: showLocationbar
 		}));
+        if(!IS_MAC){
+        	boundHotKeys.push(Hotkey({
+        		combo: "alt-d",
+        		onPress: showLocationbar
+        	}));
+        }
 	}
-	
 	boundHotKeys.push(Hotkey({
 		combo: "accel-k",
 		onPress: selectSearchBox


### PR DESCRIPTION
Note: untest on Max OS X.

References:
https://hg.mozilla.org/mozilla-central/annotate/2c9781c3e9b5/browser/base/content/browser-sets.inc#l254
https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly#w_miscellaneous
https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/system#platform
https://github.com/search?l=javascript&q=OS_TARGET+mac&ref=searchresults&type=Code&utf8=%E2%9C%93
